### PR TITLE
Use https instead of http

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,7 +57,7 @@ $('input').keypress(function (event) {
 
 function pullCurrentWeather(callback){
   $.ajax({
-    url: "http://api.wunderground.com/api/d8483e016960a875/geolookup/q/autoip.json",
+    url: "https://api.wunderground.com/api/d8483e016960a875/geolookup/q/autoip.json",
     type: "GET",
     success: function(data){
       appendZip(data);
@@ -92,7 +92,7 @@ function getWeatherAndForecast(providedLocation, callback) {
     // Forecast Req: |-----------> 1 == 2 ? false
 
     $.ajax({
-        url: "http://api.wunderground.com/api/d8483e016960a875/conditions/q/" + providedLocation + ".json",
+        url: "https://api.wunderground.com/api/d8483e016960a875/conditions/q/" + providedLocation + ".json",
         type: "GET",
         success: function(data){
             if (!data.current_observation && !data.response.error) {


### PR DESCRIPTION
This will prevent "Mixed Content" errors when the page is loaded over https (e.g. https://kimsarabia.github.io/weather-app/).

![image](https://cloud.githubusercontent.com/assets/2864371/13549085/46e84c30-e307-11e5-9fe6-fc70de247708.png)

However, when loading over `http`, it will still work. :smile: 
